### PR TITLE
Update validation rules to match current Claude Code features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 keywords = ["claude", "claude-code", "linter", "plugin", "validation"]
-requires-python = ">=3.8"
+requires-python = ">=3.8.1"
 dependencies = [
     "PyYAML>=6.0",
 ]

--- a/src/claudelint/rule.py
+++ b/src/claudelint/rule.py
@@ -100,7 +100,13 @@ class Rule(ABC):
         """
         pass
 
-    def violation(self, message: str, file_path: Path = None, line: int = None) -> RuleViolation:
+    def violation(
+        self,
+        message: str,
+        file_path: Path = None,
+        line: int = None,
+        severity: Severity = None,
+    ) -> RuleViolation:
         """
         Create a violation for this rule
 
@@ -108,13 +114,14 @@ class Rule(ABC):
             message: Violation message
             file_path: Optional file path where violation occurred
             line: Optional line number
+            severity: Override severity (defaults to rule's configured severity)
 
         Returns:
             RuleViolation instance
         """
         return RuleViolation(
             rule_id=self.rule_id,
-            severity=self.severity,
+            severity=severity if severity is not None else self.severity,
             message=message,
             file_path=file_path,
             line=line,

--- a/src/claudelint/rules/builtin/__init__.py
+++ b/src/claudelint/rules/builtin/__init__.py
@@ -40,7 +40,6 @@ from .mcp import (
     McpProhibitedRule,
 )
 
-
 # All builtin rules
 BUILTIN_RULES = [
     # Plugin structure

--- a/src/claudelint/rules/builtin/hooks.py
+++ b/src/claudelint/rules/builtin/hooks.py
@@ -12,14 +12,70 @@ from claudelint.context import RepositoryContext
 _VALID_HOOK_EVENTS = {
     "PreToolUse",
     "PostToolUse",
+    "PostToolUseFailure",
+    "PermissionRequest",
     "UserPromptSubmit",
     "Notification",
     "Stop",
+    "SubagentStart",
     "SubagentStop",
     "SessionStart",
     "SessionEnd",
     "PreCompact",
+    "TeammateIdle",
+    "TaskCompleted",
+    "ConfigChange",
+    "WorktreeCreate",
+    "WorktreeRemove",
 }
+
+# Valid hook handler types
+_VALID_HOOK_TYPES = {"command", "http", "prompt", "agent"}
+
+# Required fields per handler type
+_TYPE_REQUIRED_FIELDS = {
+    "command": {"command": str},
+    "http": {"url": str},
+    "prompt": {"prompt": str},
+    "agent": {"prompt": str},
+}
+
+# Fields restricted to specific handler types (field -> set of valid types)
+_TYPE_SPECIFIC_FIELDS = {
+    "command": {"command"},
+    "async": {"command"},
+    "url": {"http"},
+    "headers": {"http"},
+    "allowedEnvVars": {"http"},
+    "prompt": {"prompt", "agent"},
+    "model": {"prompt", "agent"},
+}
+
+# Common optional field type validation
+_OPTIONAL_FIELD_TYPES = {
+    "timeout": (int, float),
+    "async": bool,
+    "once": bool,
+    "statusMessage": str,
+    "headers": dict,
+    "allowedEnvVars": list,
+}
+
+
+def _check_field_type(value, expected_type):
+    """Check if value matches expected type, treating bool as distinct from int."""
+    if isinstance(expected_type, tuple):
+        return isinstance(value, expected_type) and not isinstance(value, bool)
+    if expected_type is bool:
+        return isinstance(value, bool)
+    return isinstance(value, expected_type) and not isinstance(value, bool)
+
+
+def _format_type_name(expected_type):
+    """Format expected type for error messages."""
+    if isinstance(expected_type, tuple):
+        return "/".join(t.__name__ for t in expected_type)
+    return expected_type.__name__
 
 
 class HooksJsonValidRule(Rule):
@@ -146,5 +202,68 @@ class HooksJsonValidRule(Rule):
                                     file_path=hooks_json,
                                 )
                             )
+                            continue
+
+                        hook_type = hook["type"]
+                        hook_path = f"{event_type}[{idx}].hooks[{hook_idx}]"
+
+                        # Validate type value
+                        if hook_type not in _VALID_HOOK_TYPES:
+                            violations.append(
+                                self.violation(
+                                    f"Event '{hook_path}' has invalid type '{hook_type}'. "
+                                    f"Valid types: {', '.join(sorted(_VALID_HOOK_TYPES))}",
+                                    file_path=hooks_json,
+                                )
+                            )
+                            continue
+
+                        # Validate type-specific required fields
+                        for field, expected_type in _TYPE_REQUIRED_FIELDS[hook_type].items():
+                            if field not in hook:
+                                violations.append(
+                                    self.violation(
+                                        f"Event '{hook_path}' of type '{hook_type}' "
+                                        f"requires a '{field}' field",
+                                        file_path=hooks_json,
+                                    )
+                                )
+                            elif not isinstance(hook[field], expected_type):
+                                violations.append(
+                                    self.violation(
+                                        f"Event '{hook_path}' field '{field}' "
+                                        f"must be a {expected_type.__name__}",
+                                        file_path=hooks_json,
+                                    )
+                                )
+
+                        # Validate type-specific field restrictions (WARNING)
+                        for field in hook:
+                            if field in _TYPE_SPECIFIC_FIELDS:
+                                valid_types = _TYPE_SPECIFIC_FIELDS[field]
+                                if hook_type not in valid_types:
+                                    violations.append(
+                                        self.violation(
+                                            f"Event '{hook_path}' field '{field}' "
+                                            f"is only valid on types: "
+                                            f"{', '.join(sorted(valid_types))}",
+                                            file_path=hooks_json,
+                                            severity=Severity.WARNING,
+                                        )
+                                    )
+
+                        # Validate common optional field types
+                        for field, expected_type in _OPTIONAL_FIELD_TYPES.items():
+                            if field not in hook:
+                                continue
+                            if not _check_field_type(hook[field], expected_type):
+                                type_name = _format_type_name(expected_type)
+                                violations.append(
+                                    self.violation(
+                                        f"Event '{hook_path}' field '{field}' "
+                                        f"must be a {type_name}",
+                                        file_path=hooks_json,
+                                    )
+                                )
 
         return violations

--- a/src/claudelint/rules/builtin/plugin_structure.py
+++ b/src/claudelint/rules/builtin/plugin_structure.py
@@ -81,11 +81,23 @@ class PluginJsonValidRule(Rule):
                 continue
 
             # Check required fields
-            required_fields = ["name", "description", "version", "author"]
+            required_fields = ["name"]
             for field in required_fields:
                 if field not in data:
                     violations.append(
                         self.violation(f"Missing required field '{field}'", file_path=plugin_json)
+                    )
+
+            # Check recommended fields (warning)
+            recommended_fields = ["description", "version", "author"]
+            for field in recommended_fields:
+                if field not in data:
+                    violations.append(
+                        self.violation(
+                            f"Missing recommended field '{field}'",
+                            file_path=plugin_json,
+                            severity=Severity.WARNING,
+                        )
                     )
 
             # Validate version format (semver)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,8 +122,7 @@ def marketplace_repo(temp_dir):
         commands_dir.mkdir()
 
         with open(commands_dir / "test.md", "w") as f:
-            f.write(
-                f"""---
+            f.write(f"""---
 description: Test command
 ---
 
@@ -140,8 +139,7 @@ Test command
 
 ## Implementation
 Do something
-"""
-            )
+""")
 
     return temp_dir
 
@@ -174,8 +172,7 @@ def flat_structure_marketplace(temp_dir):
     commands_dir.mkdir()
 
     with open(commands_dir / "test.md", "w") as f:
-        f.write(
-            """---
+        f.write("""---
 description: Test command
 ---
 
@@ -192,8 +189,7 @@ Test command for flat structure
 
 ## Implementation
 Do something
-"""
-        )
+""")
 
     # Create skills at root level
     skills_dir = temp_dir / "skills"
@@ -202,16 +198,14 @@ Do something
     skill_dir.mkdir()
 
     with open(skill_dir / "SKILL.md", "w") as f:
-        f.write(
-            """---
+        f.write("""---
 description: Test skill
 ---
 
 # Test Skill
 
 This is a test skill for flat structure.
-"""
-        )
+""")
 
     return temp_dir
 
@@ -261,8 +255,7 @@ def custom_path_marketplace(temp_dir):
     commands_dir.mkdir()
 
     with open(commands_dir / "test.md", "w") as f:
-        f.write(
-            """---
+        f.write("""---
 description: Test command
 ---
 
@@ -279,8 +272,7 @@ Test command
 
 ## Implementation
 Do something
-"""
-        )
+""")
 
     return temp_dir
 
@@ -321,8 +313,7 @@ def strict_false_marketplace(temp_dir):
     commands_dir.mkdir()
 
     with open(commands_dir / "test.md", "w") as f:
-        f.write(
-            """---
+        f.write("""---
 description: Test command
 ---
 
@@ -339,8 +330,7 @@ Test command without plugin.json
 
 ## Implementation
 Do something
-"""
-        )
+""")
 
     # Create skills
     skills_dir = plugin_dir / "skills"
@@ -349,16 +339,14 @@ Do something
     skill_dir.mkdir()
 
     with open(skill_dir / "SKILL.md", "w") as f:
-        f.write(
-            """---
+        f.write("""---
 description: Test skill
 ---
 
 # Test Skill
 
 This is a test skill without plugin.json.
-"""
-        )
+""")
 
     return temp_dir
 

--- a/tests/test_custom_rules.py
+++ b/tests/test_custom_rules.py
@@ -14,8 +14,7 @@ def test_load_valid_custom_rule(valid_plugin, temp_dir):
     """Test that a valid custom rule loads successfully"""
     # Create a valid custom rule file
     custom_rule_file = temp_dir / "custom_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -33,8 +32,7 @@ class TestCustomRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return []
-"""
-    )
+""")
 
     # Create config with custom rule
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
@@ -62,8 +60,7 @@ def test_load_custom_rule_import_error(valid_plugin, temp_dir):
     """Test that linter fails when custom rule has import errors"""
     # Create a custom rule file with import error
     custom_rule_file = temp_dir / "bad_import_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from nonexistent_module import something  # This will cause ImportError
 from typing import List
@@ -82,8 +79,7 @@ class BadImportRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return []
-"""
-    )
+""")
 
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
@@ -97,8 +93,7 @@ def test_load_custom_rule_syntax_error(valid_plugin, temp_dir):
     """Test that linter fails when custom rule has syntax errors"""
     # Create a custom rule file with syntax error
     custom_rule_file = temp_dir / "syntax_error_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -116,8 +111,7 @@ class SyntaxErrorRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return []
-"""
-    )
+""")
 
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
@@ -131,8 +125,7 @@ def test_load_custom_rule_missing_imports(valid_plugin, temp_dir):
     """Test that linter fails when custom rule can't import from claudelint"""
     # Create a custom rule file that tries to import but claudelint exports are missing
     custom_rule_file = temp_dir / "missing_export_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, NonExistentClass  # NonExistentClass doesn't exist
 from typing import List
 
@@ -151,8 +144,7 @@ class MissingExportRule(Rule):
 
     def check(self, context):
         return []
-"""
-    )
+""")
 
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
@@ -166,8 +158,7 @@ def test_load_custom_rule_relative_path(valid_plugin, temp_dir):
     """Test that custom rules with relative paths work correctly"""
     # Create a custom rule file in the plugin directory
     custom_rule_file = valid_plugin / "my_custom_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -185,8 +176,7 @@ class RelativePathRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return []
-"""
-    )
+""")
 
     # Use relative path (relative to repository root)
     config = LinterConfig(custom_rules=["./my_custom_rule.py"])
@@ -204,8 +194,7 @@ def test_load_multiple_custom_rules(valid_plugin, temp_dir):
     """Test loading multiple custom rules at once"""
     # Create two custom rule files
     custom_rule_1 = temp_dir / "custom_rule_1.py"
-    custom_rule_1.write_text(
-        """
+    custom_rule_1.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -223,12 +212,10 @@ class CustomRule1(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return []
-"""
-    )
+""")
 
     custom_rule_2 = temp_dir / "custom_rule_2.py"
-    custom_rule_2.write_text(
-        """
+    custom_rule_2.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -246,8 +233,7 @@ class CustomRule2(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return []
-"""
-    )
+""")
 
     # Create config with both custom rules
     config = LinterConfig(custom_rules=[str(custom_rule_1), str(custom_rule_2)])
@@ -266,8 +252,7 @@ def test_custom_rule_can_find_violations(valid_plugin, temp_dir):
     """Test that custom rules can actually find and report violations"""
     # Create a custom rule that always finds a violation
     custom_rule_file = temp_dir / "violation_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -285,8 +270,7 @@ class ViolationRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return [self.violation("This is a test violation")]
-"""
-    )
+""")
 
     config = LinterConfig(custom_rules=[str(custom_rule_file)])
     context = RepositoryContext(valid_plugin)
@@ -304,8 +288,7 @@ def test_custom_rule_respects_disabled_config(valid_plugin, temp_dir):
     """Test that custom rules respect the enabled/disabled config"""
     # Create a custom rule
     custom_rule_file = temp_dir / "disabled_rule.py"
-    custom_rule_file.write_text(
-        """
+    custom_rule_file.write_text("""
 from claudelint import Rule, RuleViolation, Severity, RepositoryContext
 from typing import List
 
@@ -323,8 +306,7 @@ class DisabledRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         return [self.violation("Should not see this")]
-"""
-    )
+""")
 
     # Create config with custom rule disabled
     config = LinterConfig(

--- a/tests/test_hook_rules.py
+++ b/tests/test_hook_rules.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 
 from claudelint.rules.builtin.hooks import HooksJsonValidRule
+from claudelint.rule import Severity
 from claudelint.context import RepositoryContext
 
 
@@ -36,7 +37,7 @@ def plugin_with_valid_hooks(temp_dir):
                 }
             ],
             "PreToolUse": [
-                {"matcher": ".*", "hooks": [{"type": "validation", "command": "echo 'validating'"}]}
+                {"matcher": ".*", "hooks": [{"type": "command", "command": "echo 'validating'"}]}
             ],
         }
     }
@@ -233,13 +234,21 @@ def test_all_valid_event_types(temp_dir):
     valid_events = [
         "PreToolUse",
         "PostToolUse",
+        "PostToolUseFailure",
+        "PermissionRequest",
         "UserPromptSubmit",
         "Notification",
         "Stop",
+        "SubagentStart",
         "SubagentStop",
         "SessionStart",
         "SessionEnd",
         "PreCompact",
+        "TeammateIdle",
+        "TaskCompleted",
+        "ConfigChange",
+        "WorktreeCreate",
+        "WorktreeRemove",
     ]
 
     hooks_config = {"hooks": {}}
@@ -254,3 +263,374 @@ def test_all_valid_event_types(temp_dir):
     rule = HooksJsonValidRule()
     violations = rule.check(context)
     assert len(violations) == 0
+
+
+def _make_hooks_plugin(temp_dir, hooks_config):
+    """Helper to create a plugin with a given hooks config."""
+    plugin_dir = temp_dir / "test-plugin"
+    plugin_dir.mkdir()
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+    (claude_dir / "plugin.json").write_text('{"name": "test-plugin"}')
+    hooks_dir = plugin_dir / "hooks"
+    hooks_dir.mkdir()
+    (hooks_dir / "hooks.json").write_text(json.dumps(hooks_config))
+    return plugin_dir
+
+
+def test_valid_hook_type_command(temp_dir):
+    """Test that valid command hook type passes"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "command", "command": "echo test"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_valid_hook_type_http(temp_dir):
+    """Test that valid http hook type passes"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "http", "url": "https://example.com/hook"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_valid_hook_type_prompt(temp_dir):
+    """Test that valid prompt hook type passes"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "prompt", "prompt": "check the output"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_valid_hook_type_agent(temp_dir):
+    """Test that valid agent hook type passes"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "agent", "prompt": "review changes"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_invalid_hook_type_value(temp_dir):
+    """Test that invalid hook type value is detected"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "invalid_type", "command": "echo test"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "invalid type" in violations[0].message
+
+
+def test_command_type_missing_command_field(temp_dir):
+    """Test that command type without command field is detected"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "command"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "requires a 'command' field" in violations[0].message
+
+
+def test_http_type_missing_url_field(temp_dir):
+    """Test that http type without url field is detected"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "http"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "requires a 'url' field" in violations[0].message
+
+
+def test_prompt_type_missing_prompt_field(temp_dir):
+    """Test that prompt type without prompt field is detected"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "prompt"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "requires a 'prompt' field" in violations[0].message
+
+
+def test_type_specific_field_restriction_warning(temp_dir):
+    """Test that using async on http hook produces a warning"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "http",
+                                "url": "https://example.com",
+                                "async": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.WARNING
+    assert "only valid on types" in violations[0].message
+
+
+def test_field_type_validation_timeout_string(temp_dir):
+    """Test that timeout as string is detected"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo test",
+                                "timeout": "5000",
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "timeout" in violations[0].message
+    assert "int/float" in violations[0].message
+
+
+def test_field_type_validation_timeout_number(temp_dir):
+    """Test that timeout as number passes"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo test",
+                                "timeout": 5000,
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 0
+
+
+def test_headers_on_command_type_warning(temp_dir):
+    """Test that headers on command type produces a warning"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo test",
+                                "headers": {"Authorization": "Bearer token"},
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.WARNING
+    assert "headers" in violations[0].message
+
+
+def test_agent_type_missing_prompt_field(temp_dir):
+    """Test that agent type without prompt field is detected"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "agent"}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "requires a 'prompt' field" in violations[0].message
+
+
+def test_required_field_wrong_type(temp_dir):
+    """Test that required field with wrong type is detected (e.g. command as int)"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [{"type": "command", "command": 123}],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "must be a str" in violations[0].message
+
+
+def test_timeout_as_boolean_rejected(temp_dir):
+    """Test that timeout as boolean is rejected (bool is subclass of int)"""
+    plugin_dir = _make_hooks_plugin(
+        temp_dir,
+        {
+            "hooks": {
+                "PostToolUse": [
+                    {
+                        "matcher": ".*",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "echo test",
+                                "timeout": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+    )
+    context = RepositoryContext(plugin_dir)
+    rule = HooksJsonValidRule()
+    violations = rule.check(context)
+    assert len(violations) == 1
+    assert "timeout" in violations[0].message

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -117,3 +117,60 @@ def test_marketplace_registration_fails(marketplace_repo):
     violations = rule.check(context)
     assert len(violations) == 1
     assert "plugin-three" in violations[0].message
+
+
+def test_plugin_json_name_only_warns_for_recommended(temp_dir):
+    """Test that plugin.json with only 'name' produces warnings for recommended fields"""
+    import json
+
+    plugin_dir = temp_dir / "minimal-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "minimal-plugin"}, f)
+
+    (plugin_dir / "commands").mkdir()
+
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule()
+    violations = rule.check(context)
+
+    # Should have 3 warnings for missing recommended fields, no errors
+    assert len(violations) == 3
+    for v in violations:
+        assert v.severity == Severity.WARNING
+        assert "recommended" in v.message
+
+    recommended = {v.message.split("'")[1] for v in violations}
+    assert recommended == {"description", "version", "author"}
+
+
+def test_plugin_json_missing_name_is_error(temp_dir):
+    """Test that plugin.json missing 'name' produces an error"""
+    import json
+
+    plugin_dir = temp_dir / "no-name-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"description": "A plugin without a name"}, f)
+
+    (plugin_dir / "commands").mkdir()
+
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule()
+    violations = rule.check(context)
+
+    errors = [v for v in violations if v.severity == Severity.ERROR]
+    warnings = [v for v in violations if v.severity == Severity.WARNING]
+
+    assert len(errors) == 1
+    assert "name" in errors[0].message
+    # version and author are missing -> 2 warnings
+    assert len(warnings) == 2


### PR DESCRIPTION
## Summary

- Expand hook event types from 9 to 17 to match current Claude Code docs
- Add hook handler type validation (command, http, prompt, agent) with type-specific required fields and field restriction warnings
- Relax plugin.json required fields: only `name` is required per spec; `description`/`version`/`author` are now recommended (WARNING)
- Add `severity` parameter to `Rule.violation()` for cleaner mixed-severity rules

## Changes

**`src/claudelint/rule.py`**
- Add optional `severity` parameter to `Rule.violation()` to allow overriding the rule's configured severity

**`src/claudelint/rules/builtin/hooks.py`**
- Add 8 new event types: `PostToolUseFailure`, `PermissionRequest`, `SubagentStart`, `TeammateIdle`, `TaskCompleted`, `ConfigChange`, `WorktreeCreate`, `WorktreeRemove`
- Add handler type validation with `_VALID_HOOK_TYPES`, `_TYPE_REQUIRED_FIELDS`, `_TYPE_SPECIFIC_FIELDS`, `_OPTIONAL_FIELD_TYPES`
- Extract `_check_field_type()` and `_format_type_name()` helpers for consistent bool/int handling

**`src/claudelint/rules/builtin/plugin_structure.py`**
- Only `name` is required (ERROR); `description`, `version`, `author` are recommended (WARNING)

**`tests/test_hook_rules.py`**
- Update event types list to include all 17 events
- Add 15 new tests covering valid/invalid hook types, type-specific required fields, field restrictions, field type validation, and edge cases

**`tests/test_rules.py`**
- Add tests verifying required vs recommended field severity distinction

**`pyproject.toml`**
- Bump `requires-python` from `>=3.8` to `>=3.8.1` to fix flake8 dependency resolution with uv

## Testing

All 104 tests pass:
```
uv run --extra dev pytest tests/ -v
```