### PR TITLE
Make recommended-fields configurable on plugin-json-valid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ cython_debug/
 examples/test-repos/
 .work/
 .claude/
+uv.lock

--- a/src/claudelint/config.py
+++ b/src/claudelint/config.py
@@ -54,7 +54,11 @@ class LinterConfig:
             rules={
                 # Plugin structure rules
                 "plugin-json-required": {"enabled": True, "severity": "error"},
-                "plugin-json-valid": {"enabled": True, "severity": "error"},
+                "plugin-json-valid": {
+                    "enabled": True,
+                    "severity": "error",
+                    "recommended-fields": ["description", "version", "author"],
+                },
                 "plugin-naming": {"enabled": True, "severity": "warning"},
                 "commands-dir-required": {
                     "enabled": False,

--- a/src/claudelint/linter.py
+++ b/src/claudelint/linter.py
@@ -44,8 +44,11 @@ class ClaudeLinter:
         from .rules.builtin import BUILTIN_RULES
 
         for rule_class in BUILTIN_RULES:
-            # Create instance with config
-            rule_instance = rule_class(self.config.get_rule_config(rule_class.rule_id))
+            # Instantiate to discover rule_id (a property, not accessible on the class)
+            rule_instance = rule_class()
+            config = self.config.get_rule_config(rule_instance.rule_id)
+            if config:
+                rule_instance = rule_class(config)
 
             # Check if enabled for this context
             if self.config.is_rule_enabled(rule_instance.rule_id, self.context):
@@ -76,9 +79,11 @@ class ClaudeLinter:
         for name in dir(module):
             obj = getattr(module, name)
             if isinstance(obj, type) and issubclass(obj, Rule) and obj is not Rule:
-
-                # Create instance
-                rule_instance = obj(self.config.get_rule_config(obj.rule_id))
+                # Instantiate to discover rule_id (a property, not accessible on the class)
+                rule_instance = obj()
+                config = self.config.get_rule_config(rule_instance.rule_id)
+                if config:
+                    rule_instance = obj(config)
 
                 # Check if enabled
                 if self.config.is_rule_enabled(rule_instance.rule_id, self.context):
@@ -117,7 +122,9 @@ class ClaudeLinter:
         info = sum(1 for v in violations if v.severity == Severity.INFO)
         return errors, warnings, info
 
-    def format_results(self, violations: List[RuleViolation], verbose: bool = False) -> str:
+    def format_results(
+        self, violations: List[RuleViolation], verbose: bool = False
+    ) -> str:
         """
         Format violations for display
 

--- a/src/claudelint/rules/builtin/plugin_structure.py
+++ b/src/claudelint/rules/builtin/plugin_structure.py
@@ -39,13 +39,17 @@ class PluginJsonRequiredRule(Rule):
                         # When strict: false, plugin.json is optional
                         continue
 
-                violations.append(self.violation("Missing plugin.json", file_path=plugin_json))
+                violations.append(
+                    self.violation("Missing plugin.json", file_path=plugin_json)
+                )
 
         return violations
 
 
 class PluginJsonValidRule(Rule):
     """Check that plugin.json is valid and has required fields"""
+
+    DEFAULT_RECOMMENDED_FIELDS = ["description", "version", "author"]
 
     @property
     def rule_id(self) -> str:
@@ -60,6 +64,9 @@ class PluginJsonValidRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
+        recommended_fields = self.config.get(
+            "recommended-fields", self.DEFAULT_RECOMMENDED_FIELDS
+        )
 
         for plugin_path in context.plugins:
             plugin_json = plugin_path / ".claude-plugin" / "plugin.json"
@@ -72,7 +79,9 @@ class PluginJsonValidRule(Rule):
                 with open(plugin_json, "r") as f:
                     data = json.load(f)
             except json.JSONDecodeError as e:
-                violations.append(self.violation(f"Invalid JSON: {e}", file_path=plugin_json))
+                violations.append(
+                    self.violation(f"Invalid JSON: {e}", file_path=plugin_json)
+                )
                 continue
             except IOError as e:
                 violations.append(
@@ -85,11 +94,12 @@ class PluginJsonValidRule(Rule):
             for field in required_fields:
                 if field not in data:
                     violations.append(
-                        self.violation(f"Missing required field '{field}'", file_path=plugin_json)
+                        self.violation(
+                            f"Missing required field '{field}'", file_path=plugin_json
+                        )
                     )
 
             # Check recommended fields (warning)
-            recommended_fields = ["description", "version", "author"]
             for field in recommended_fields:
                 if field not in data:
                     violations.append(
@@ -117,7 +127,8 @@ class PluginJsonValidRule(Rule):
                 if not isinstance(author, dict) or "name" not in author:
                     violations.append(
                         self.violation(
-                            "Author must be an object with 'name' field", file_path=plugin_json
+                            "Author must be an object with 'name' field",
+                            file_path=plugin_json,
                         )
                     )
 
@@ -147,7 +158,8 @@ class PluginNamingRule(Rule):
             if not self._is_kebab_case(plugin_name):
                 violations.append(
                     self.violation(
-                        f"Plugin name '{plugin_name}' should use kebab-case", file_path=plugin_path
+                        f"Plugin name '{plugin_name}' should use kebab-case",
+                        file_path=plugin_path,
                     )
                 )
 
@@ -213,7 +225,8 @@ class CommandsExistRule(Rule):
             if not command_files:
                 violations.append(
                     self.violation(
-                        "No command files found in commands directory", file_path=commands_dir
+                        "No command files found in commands directory",
+                        file_path=commands_dir,
                     )
                 )
 
@@ -241,7 +254,9 @@ class PluginReadmeRule(Rule):
             readme = plugin_path / "README.md"
             if not readme.exists():
                 violations.append(
-                    self.violation("Missing README.md (recommended)", file_path=plugin_path)
+                    self.violation(
+                        "Missing README.md (recommended)", file_path=plugin_path
+                    )
                 )
 
         return violations

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -74,3 +74,19 @@ def test_linter_respects_disabled_rules(valid_plugin):
 
     # Should have no rules loaded
     assert len(linter.rules) == 0
+
+
+def test_linter_passes_rule_config(valid_plugin):
+    """Test that per-rule config from .claudelint.yaml reaches rule instances"""
+    context = RepositoryContext(valid_plugin)
+    config = LinterConfig.default()
+
+    # Override recommended-fields for plugin-json-valid
+    config.rules["plugin-json-valid"]["recommended-fields"] = ["description"]
+
+    linter = ClaudeLinter(context, config)
+
+    # Find the plugin-json-valid rule and verify it got the config
+    pjv_rules = [r for r in linter.rules if r.rule_id == "plugin-json-valid"]
+    assert len(pjv_rules) == 1
+    assert pjv_rules[0].config.get("recommended-fields") == ["description"]

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -148,6 +148,57 @@ def test_plugin_json_name_only_warns_for_recommended(temp_dir):
     assert recommended == {"description", "version", "author"}
 
 
+def test_plugin_json_custom_recommended_fields(temp_dir):
+    """Test that recommended-fields config controls which fields are checked"""
+    import json
+
+    plugin_dir = temp_dir / "minimal-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "minimal-plugin"}, f)
+
+    (plugin_dir / "commands").mkdir()
+
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule({"recommended-fields": ["description", "version"]})
+    violations = rule.check(context)
+
+    # Should have 2 warnings (description, version) but NOT author
+    assert len(violations) == 2
+    for v in violations:
+        assert v.severity == Severity.WARNING
+        assert "recommended" in v.message
+
+    recommended = {v.message.split("'")[1] for v in violations}
+    assert recommended == {"description", "version"}
+
+
+def test_plugin_json_empty_recommended_fields(temp_dir):
+    """Test that empty recommended-fields disables all recommended field checks"""
+    import json
+
+    plugin_dir = temp_dir / "minimal-plugin"
+    plugin_dir.mkdir()
+
+    claude_dir = plugin_dir / ".claude-plugin"
+    claude_dir.mkdir()
+
+    with open(claude_dir / "plugin.json", "w") as f:
+        json.dump({"name": "minimal-plugin"}, f)
+
+    (plugin_dir / "commands").mkdir()
+
+    context = RepositoryContext(plugin_dir)
+    rule = PluginJsonValidRule({"recommended-fields": []})
+    violations = rule.check(context)
+
+    assert len(violations) == 0
+
+
 def test_plugin_json_missing_name_is_error(temp_dir):
     """Test that plugin.json missing 'name' produces an error"""
     import json


### PR DESCRIPTION
Add a 'recommended-fields' config option to the plugin-json-valid rule so users can control which fields produce warnings. The default remains ['description', 'version', 'author'] for backward compatibility.

Also fix a bug where rule_class.rule_id accessed the property descriptor on the class instead of the string value, causing get_rule_config() to always return {} for builtin rules. Per-rule config from .claudelint.yaml was silently ignored during Rule.__init__.