### PR TITLE
CI chores: black 26, Actions node.js update, version bump

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Log in to Container registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black flake8
+          pip install "black>=26,<27" flake8
 
       - name: Check formatting with black
         run: black --check src/ tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -42,10 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "black>=23.0",
+    "black>=26,<27",
     "flake8>=6.0",
     "mypy>=1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claudelint"
-version = "0.3.5"
+version = "0.3.6"
 description = "A configurable, rule-based linter for Claude Code plugins"
 readme = "README.md"
 authors = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pytest>=7.0
 pytest-cov>=4.0
 
 # Code quality
-black>=23.0
+black>=26,<27
 flake8>=6.0
 mypy>=1.0
 

--- a/src/claudelint/__init__.py
+++ b/src/claudelint/__init__.py
@@ -2,7 +2,7 @@
 claudelint - A configurable linter for Claude Code plugins
 """
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 from .rule import Rule, RuleViolation, Severity
 from .context import RepositoryContext

--- a/src/claudelint/linter.py
+++ b/src/claudelint/linter.py
@@ -122,9 +122,7 @@ class ClaudeLinter:
         info = sum(1 for v in violations if v.severity == Severity.INFO)
         return errors, warnings, info
 
-    def format_results(
-        self, violations: List[RuleViolation], verbose: bool = False
-    ) -> str:
+    def format_results(self, violations: List[RuleViolation], verbose: bool = False) -> str:
         """
         Format violations for display
 

--- a/src/claudelint/rules/builtin/plugin_structure.py
+++ b/src/claudelint/rules/builtin/plugin_structure.py
@@ -39,9 +39,7 @@ class PluginJsonRequiredRule(Rule):
                         # When strict: false, plugin.json is optional
                         continue
 
-                violations.append(
-                    self.violation("Missing plugin.json", file_path=plugin_json)
-                )
+                violations.append(self.violation("Missing plugin.json", file_path=plugin_json))
 
         return violations
 
@@ -64,9 +62,7 @@ class PluginJsonValidRule(Rule):
 
     def check(self, context: RepositoryContext) -> List[RuleViolation]:
         violations = []
-        recommended_fields = self.config.get(
-            "recommended-fields", self.DEFAULT_RECOMMENDED_FIELDS
-        )
+        recommended_fields = self.config.get("recommended-fields", self.DEFAULT_RECOMMENDED_FIELDS)
 
         for plugin_path in context.plugins:
             plugin_json = plugin_path / ".claude-plugin" / "plugin.json"
@@ -79,9 +75,7 @@ class PluginJsonValidRule(Rule):
                 with open(plugin_json, "r") as f:
                     data = json.load(f)
             except json.JSONDecodeError as e:
-                violations.append(
-                    self.violation(f"Invalid JSON: {e}", file_path=plugin_json)
-                )
+                violations.append(self.violation(f"Invalid JSON: {e}", file_path=plugin_json))
                 continue
             except IOError as e:
                 violations.append(
@@ -94,9 +88,7 @@ class PluginJsonValidRule(Rule):
             for field in required_fields:
                 if field not in data:
                     violations.append(
-                        self.violation(
-                            f"Missing required field '{field}'", file_path=plugin_json
-                        )
+                        self.violation(f"Missing required field '{field}'", file_path=plugin_json)
                     )
 
             # Check recommended fields (warning)
@@ -254,9 +246,7 @@ class PluginReadmeRule(Rule):
             readme = plugin_path / "README.md"
             if not readme.exists():
                 violations.append(
-                    self.violation(
-                        "Missing README.md (recommended)", file_path=plugin_path
-                    )
+                    self.violation("Missing README.md (recommended)", file_path=plugin_path)
                 )
 
         return violations


### PR DESCRIPTION
## Summary

- Upgrade to black 26 and pin version range (`>=26,<27`) to prevent formatting drift between local and CI
- Bump GitHub Actions (`actions/checkout` v4→v5, `actions/setup-python` v5→v6) to resolve Node.js 20 deprecation warnings
- Bump version

## Test plan

- [x] CI lint job passes with black 26
- [x] No Node.js 20 deprecation warnings in Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)